### PR TITLE
Order matters, make AWS happy

### DIFF
--- a/listener-rule-http.tf
+++ b/listener-rule-http.tf
@@ -54,11 +54,6 @@ resource "aws_alb_listener_rule" "cognito_domain_http" {
   priority     = "${var.cognito_domain_priority_init + count.index}"
 
   action {
-    type             = "forward"
-    target_group_arn = "${aws_alb_target_group.app.arn}"
-  }
-
-  action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
@@ -66,6 +61,11 @@ resource "aws_alb_listener_rule" "cognito_domain_http" {
       user_pool_client_id = "${var.cognito_user_pool_client_id}"
       user_pool_domain    = "${var.cognito_user_pool_domain}"
     }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.app.arn}"
   }
 
   condition {
@@ -86,11 +86,6 @@ resource "aws_alb_listener_rule" "cognito_domain_http_custom" {
   priority     = "${var.cognito_domain_priority_init + count.index}"
 
   action {
-    type             = "forward"
-    target_group_arn = "${var.app_target_group_arn}"
-  }
-
-  action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
@@ -98,6 +93,11 @@ resource "aws_alb_listener_rule" "cognito_domain_http_custom" {
       user_pool_client_id = "${var.cognito_user_pool_client_id}"
       user_pool_domain    = "${var.cognito_user_pool_domain}"
     }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${var.app_target_group_arn}"
   }
 
   condition {
@@ -223,6 +223,16 @@ resource "aws_alb_listener_rule" "cognito_url_http" {
   priority     = "${var.cognito_url_priority_init + count.index}"
 
   action {
+    type = "authenticate-cognito"
+
+    authenticate_cognito {
+      user_pool_arn       = "${var.cognito_user_pool_arn}"
+      user_pool_client_id = "${var.cognito_user_pool_client_id}"
+      user_pool_domain    = "${var.cognito_user_pool_domain}"
+    }
+  }
+
+  action {
     type             = "forward"
     target_group_arn = "${aws_alb_target_group.app.arn}"
   }
@@ -242,6 +252,16 @@ resource "aws_alb_listener_rule" "cognito_url_http_custom" {
   count        = "${var.setup_listener_rule && var.enable_http_rules && var.setup_target_group == 0 ? length(var.cognito_urls) : 0}"
   listener_arn = "${var.alb_listener_http_arn}"
   priority     = "${var.cognito_url_priority_init + count.index}"
+
+  action {
+    type = "authenticate-cognito"
+
+    authenticate_cognito {
+      user_pool_arn       = "${var.cognito_user_pool_arn}"
+      user_pool_client_id = "${var.cognito_user_pool_client_id}"
+      user_pool_domain    = "${var.cognito_user_pool_domain}"
+    }
+  }
 
   action {
     type             = "forward"

--- a/listener-rule-https.tf
+++ b/listener-rule-https.tf
@@ -53,11 +53,6 @@ resource "aws_alb_listener_rule" "cognito_domain_https" {
   priority     = "${var.cognito_domain_priority_init + count.index}"
 
   action {
-    type             = "forward"
-    target_group_arn = "${aws_alb_target_group.app.arn}"
-  }
-
-  action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
@@ -65,6 +60,11 @@ resource "aws_alb_listener_rule" "cognito_domain_https" {
       user_pool_client_id = "${var.cognito_user_pool_client_id}"
       user_pool_domain    = "${var.cognito_user_pool_domain}"
     }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.app.arn}"
   }
 
   condition {
@@ -84,11 +84,6 @@ resource "aws_alb_listener_rule" "cognito_domain_https_custom" {
   priority     = "${var.cognito_domain_priority_init + count.index}"
 
   action {
-    type             = "forward"
-    target_group_arn = "${var.app_target_group_arn}"
-  }
-
-  action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
@@ -96,6 +91,11 @@ resource "aws_alb_listener_rule" "cognito_domain_https_custom" {
       user_pool_client_id = "${var.cognito_user_pool_client_id}"
       user_pool_domain    = "${var.cognito_user_pool_domain}"
     }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${var.app_target_group_arn}"
   }
 
   condition {
@@ -223,11 +223,6 @@ resource "aws_alb_listener_rule" "cognito_url_https" {
   priority     = "${var.cognito_url_priority_init + count.index}"
 
   action {
-    type             = "forward"
-    target_group_arn = "${aws_alb_target_group.app.arn}"
-  }
-
-  action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
@@ -235,6 +230,11 @@ resource "aws_alb_listener_rule" "cognito_url_https" {
       user_pool_client_id = "${var.cognito_user_pool_client_id}"
       user_pool_domain    = "${var.cognito_user_pool_domain}"
     }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.app.arn}"
   }
 
   condition {
@@ -254,11 +254,6 @@ resource "aws_alb_listener_rule" "cognito_url_https_custom" {
   priority     = "${var.cognito_url_priority_init + count.index}"
 
   action {
-    type             = "forward"
-    target_group_arn = "${var.app_target_group_arn}"
-  }
-
-  action {
     type = "authenticate-cognito"
 
     authenticate_cognito {
@@ -266,6 +261,11 @@ resource "aws_alb_listener_rule" "cognito_url_https_custom" {
       user_pool_client_id = "${var.cognito_user_pool_client_id}"
       user_pool_domain    = "${var.cognito_user_pool_domain}"
     }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${var.app_target_group_arn}"
   }
 
   condition {


### PR DESCRIPTION
Fail to apply cognito config when using wrong ordering.
```Error: Error applying plan:

1 error(s) occurred:

* module.ms_interstitial_service.aws_alb_listener_rule.cognito_url_https: 1 error(s) occurred:

* aws_alb_listener_rule.cognito_url_https: Error creating LB Listener Rule: InvalidLoadBalancerAction: An action of type 'forward' must have a higher order than all other actions
	status code: 400, request id: eacc59d0-6028-11e9-b052-9f336b191daf

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```